### PR TITLE
:presence option to enable nil in lookup attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ types and engine types, each must have a differently-named lookup. However, for
 terseness, the `:as` parameter lets you specify a short alias so you can call
 `car.type` and not `car.car_type`.
 
+The lookup macro also can have the `:presence` parameter which when set to `false`
+allows the lookup attr to be nil. The default is that the lookup has to be present.
+
 The only remaining thing is to define your migrations for creating the actual database tables. After all, that's something you only want to do once and not every time this class loads, so this isn't the place for it. However, it's easy enough to create your own scaffolds so that 
 
      rails generate migration create_car_type_lookup_for_car

--- a/lib/rails_lookup.rb
+++ b/lib/rails_lookup.rb
@@ -46,6 +46,7 @@ module RailsLookup
           end
 
           def self.gen_id_for(val)
+            return nil if val.nil?
             id = id_for val
             if id.nil?
               #Define this new possible value

--- a/lib/rails_lookup.rb
+++ b/lib/rails_lookup.rb
@@ -138,7 +138,9 @@ module RailsLookup
 
       #Might need to be in class_eval
       belongs_to lookup_name.to_s.to_sym, :foreign_key => "#{as_name}"
-      validates as_name.to_s.to_sym, :presence => true
+      if opts[:presence] != false
+        validates as_name.to_s.to_sym, :presence => true
+      end
 
       # Prefill the hashes from the DB - requires an active connection
       all_vals = cls.all

--- a/test/20110808002412_create_test_lookup_db.rb
+++ b/test/20110808002412_create_test_lookup_db.rb
@@ -17,10 +17,19 @@ class CreateTestLookupDb < ActiveRecord::Migration
 
       t.timestamps
     end
+    create_table :spaceships do |t|
+      t.integer :cargo
+      t.string :name
+
+      t.timestamps
+    end
     create_table :plane_kinds do |t|
       t.string :name
     end
     create_table :car_colors do |t|
+      t.string :name
+    end
+    create_table :cargos do |t|
       t.string :name
     end
   end
@@ -31,5 +40,7 @@ class CreateTestLookupDb < ActiveRecord::Migration
     drop_table :car_colors
     drop_table :planes
     drop_table :plane_kinds
+    drop_table :spaceships
+    drop_table :cargos
   end
 end

--- a/test/lookup_test.rb
+++ b/test/lookup_test.rb
@@ -41,6 +41,11 @@ class Plane < ActiveRecord::Base
   lookup :plane_kind, :as => :kind
 end
 
+class Spaceship < ActiveRecord::Base
+  include RailsLookup
+  lookup :cargo, :presence => false
+end
+
 class LookupTest < MiniTest::Unit::TestCase
 
   def setup
@@ -100,6 +105,8 @@ class LookupTest < MiniTest::Unit::TestCase
     ferrari_reloaded = Car.all.last
     assert_equal "Yellow", ferrari_reloaded.color
     assert_equal "Sports", ferrari_reloaded.kind
+    empty_spaceship = Spaceship.create!(:name => "Nautilus")
+    assert_equal nil, empty_spaceship.cargo
   end
 
   def test_string_setting_and_getting

--- a/test/lookup_test.rb
+++ b/test/lookup_test.rb
@@ -107,6 +107,10 @@ class LookupTest < MiniTest::Unit::TestCase
     assert_equal "Sports", ferrari_reloaded.kind
     empty_spaceship = Spaceship.create!(:name => "Nautilus")
     assert_equal nil, empty_spaceship.cargo
+    unloaded_spaceship = Spaceship.create!(:name => "Event Horizon", :cargo => "Black Matter")
+    assert_equal "Black Matter", unloaded_spaceship.cargo
+    unloaded_spaceship.cargo= nil
+    assert_equal nil, unloaded_spaceship.cargo
   end
 
   def test_string_setting_and_getting

--- a/test/lookup_test.rb
+++ b/test/lookup_test.rb
@@ -18,7 +18,10 @@ conn = ActiveRecord::Base.establish_connection(
   timeout: 5000
 )
 puts "Established connection!" unless conn.nil?
-CreateTestLookupDb.migrate(:down) # Connection has to be established for this to work
+begin
+  CreateTestLookupDb.migrate(:down) # Connection has to be established for this to work
+rescue
+end
 CreateTestLookupDb.migrate(:up)
 
 class Car < ActiveRecord::Base


### PR DESCRIPTION
Hi,

I found your gem quite useful since I'm trying to use (over?)normalized schema in my project. After I used it in quite a lot of places I found that it adds a validation for presence of the lookup attribute. In some situations it is not desirable, so I implemented a solution in my branch. The visible part is the :presence option for lookup method which takes a boolean value. The default behavior is to have the validation (so it shouldn't break existing code), but if :presence is false the validation is not injected in the parent class. I also added test to check if it behaves properly. Please pull the feature if you find it useul.

Regards,

Mateusz
